### PR TITLE
Simplification du code (else non indispensable)

### DIFF
--- a/src/main/java/co/simplon/prairie/FizzBuzz.java
+++ b/src/main/java/co/simplon/prairie/FizzBuzz.java
@@ -27,18 +27,14 @@ public class FizzBuzz {
     }
 
     protected String determinerCorrespondance(int entier) {
-    if (entier == 0) 
-        return Integer.toString (0) ;
-
-    else if (entier % 3 == 0) 
-        return "Fizz" ;
+        if (entier == 0) 
+            return "0";
+        if (entier % 3 == 0) 
+            return "Fizz" ;
+        if (entier % 5 == 0)
+            return "Buzz" ;
  
-    else if (entier % 5 == 0)
-        return "Buzz" ;
-
-    else 
         return Integer.toString (entier) ;
-    
     }
 }
  


### PR DESCRIPTION
Intéressant dans ce cas de ne pas utiliser les accolades : elles ne sont en effet pas nécessaires quand il n'y a qu'une seule instruction à effectuer. Par contre, elles deviendraient indispensables si tu avais 2 instructions.

ex. :

if (entier == 0) {
    String resultat = "0";
    return resultat;
}
